### PR TITLE
Add net48 test target, remove `<PublicSign>` from the non-NET7 distributables

### DIFF
--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -26,7 +26,7 @@
         <PackageReleaseNotes>Made signing more compatible</PackageReleaseNotes>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>InvertedTomato.Crc.snk</AssemblyOriginatorKeyFile>
-        <PublicSign>true</PublicSign>
+        <!--<PublicSign>true</PublicSign>-->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>

--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -26,11 +26,15 @@
         <PackageReleaseNotes>Made signing more compatible</PackageReleaseNotes>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>InvertedTomato.Crc.snk</AssemblyOriginatorKeyFile>
-        <!--<PublicSign>true</PublicSign>-->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <PublicSign>true</PublicSign>
+        <PublicSign Condition="$(TargetFramework.StartsWith('netstandard'))">false</PublicSign>
+    </PropertyGroup>
+	
     <PropertyGroup>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net48</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
I noticed the library uses a few difference TFMs but only runs tests on .NET7. I tried adding a net48 test target to exercise the netstandard builds, but ran into a strong naming issue. I've worked around it by temporarily removing the `<PublicSign>` on the netstandard builds. All builds still use `<SignAssembly>` and `sn -Tp` shows a public key on the assembly for both netstandard + net7 builds.

The tests now pass for me on both net48 + net7 runtimes 😄 

While the [main docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/security#publicsign) don't mention much about compatibility, I found a bit of a [write-up here](https://github.com/dotnet/runtime/blob/main/docs/project/public-signing.md) outlining a few of the known issues within .NET Framework.